### PR TITLE
Offset miscalculated

### DIFF
--- a/js/jquery.scrollorama.js
+++ b/js/jquery.scrollorama.js
@@ -40,7 +40,7 @@
 				var block = scrollorama.settings.blocks.eq(i);
 				blocks.push({
 					block: block,
-					top: block.offset().top,
+					top: block.offset().top - parseInt(block.css('margin-top'), 10),
 					pin: 0,
 					animations:[]
 				});


### PR DESCRIPTION
If a block already has a "margin-top" property set, then that increases block.offset().top. When you copy block.offset().top directly to the top property, you need to substract that margin, to avoid being of by it. Hope that was clear..
