### PR TITLE
added background-position and text-shadow property

### DIFF
--- a/js/jquery.scrollorama.js
+++ b/js/jquery.scrollorama.js
@@ -171,8 +171,14 @@
 					}
 				}
 			}
-			else if(prop === 'background-position' || prop === 'background-position-x' || prop === 'background-position-x' ){
-				target.css(prop,val+'px');
+			else if(prop === 'background-position-x' || prop === 'background-position-y' ){
+				var currentPosition = target.css('background-position').split(' ');
+				if(prop === 'background-position-x'){
+					target.css('background-position',val+'px '+currentPosition[1])
+				}
+				if(prop === 'background-position-y'){
+					target.css('background-position',currentPosition[0]+' '+val+'px')
+				}
 			} 
 			else if(prop === 'text-shadow' ){
 				target.css(prop,'0px 0px '+val+'px #ffffff');
@@ -180,6 +186,7 @@
 				target.css(prop, val);
 			}	
 		}
+		
 		
 		// PUBLIC FUNCTIONS
 		scrollorama.animate = function(target) {


### PR DESCRIPTION
I've got a live site with this code running here: http://www.jesusculture.com/nyla/ny.html
I had to redo the background-position property part. I had developed it testing only on chrome, only to realize that 'background-property-x/y' don't work on firefox. New solution seems to work just fine though and its a MUST have for selling the parallax efffect. 
