### PR TITLE
Fixed IE8 problem determining 'top' with enablePin set to false 

### DIFF
--- a/js/jquery.scrollorama.js
+++ b/js/jquery.scrollorama.js
@@ -181,7 +181,8 @@
 			var currBlockIndex = 0, i;
 			for (i=0; i<blocks.length; i++) {
 				// check if block is in view
-				if (blocks[i].top <= scrollTop - scrollorama.settings.offset) { currBlockIndex = i; }
+				var offset = $(blocks[i].block).offset();
+				if (offset.top <= scrollTop - scrollorama.settings.offset) { currBlockIndex = i; }
 			}
 			return currBlockIndex;
 		}


### PR DESCRIPTION
Hi,

I've changed the way 'top' is calculated using .offset() property instead of the basic CSS 'top'. Now scrollorama works also under IE8 when enablePin is set to false.

Sandro.
