### PR TITLE
Adding a method to destroy Scrollorama. 

### DIFF
--- a/js/jquery.scrollorama.js
+++ b/js/jquery.scrollorama.js
@@ -344,6 +344,30 @@
 			return scrollpoints;
 		};
 		
+		// Remove scrollorama
+		scrollorama.destroy = function () {
+			// Remove animations
+			for (i=0; i<blocks.length; i++) {
+				// Remove CSS rules
+				blocks[i].block.css({
+					top: '',
+					position: ''
+				});
+				
+				// Remove scrolloroma-specific attributes
+				delete blocks[i].animations;
+				delete blocks[i].top;
+				delete blocks[i].pin;
+			}
+
+			// Unbind the window scroll event
+			$(window).off('scroll.scrollorama');
+			$('#scroll-wrap').remove();
+			
+			// Remove the scrolloroma object
+			delete scrollorama;
+		};
+		
 		
 		// INIT
 		init();


### PR DESCRIPTION
This is useful for re-initializing the plugin and memory management.

Typical use cases are:
- We need to remove scrolloroma from the DOM from a site that has dynamic content
- Dynamic content's height changed, rendering scrolloroma's animations useless.
