### PR TITLE
Namespacing window's scroll event

### DIFF
--- a/js/jquery.scrollorama.js
+++ b/js/jquery.scrollorama.js
@@ -64,7 +64,7 @@
 			
 			latestKnownScrollY = 0;
             ticking = false;
-            $(window).scroll( onScroll );
+            $(window).on( 'scroll.scrollorama', onScroll );
 		}
 
 		function onScroll() {


### PR DESCRIPTION
So the plugin can successfully unbind itself without unbinding any other events that could be possibly created by the user.
