### PR TITLE
Allow startVal/endVal to be set as functions

### DIFF
--- a/js/jquery.scrollorama.js
+++ b/js/jquery.scrollorama.js
@@ -311,8 +311,8 @@
 					delay: anim.delay,
 					duration: anim.duration,
 					property: anim.property,
-					startVal: anim.start !== undefined ? anim.start : parseInt(target.css(anim.property),10),	// if undefined, use current css value
-					endVal: anim.end !== undefined ? anim.end : parseInt(target.css(anim.property),10),			// if undefined, use current css value
+					startVal: anim.start !== undefined ? typeof(anim.start) == 'function' ? anim.start() : anim.start : parseInt(target.css(anim.property),10),	// if undefined, use current css value
+					endVal: anim.end !== undefined ? typeof(anim.end) == 'function' ? anim.end() : anim.end : parseInt(target.css(anim.property),10),			// if undefined, use current css value
 					baseline: anim.baseline !== undefined ? anim.baseline : 'bottom',
 					easing: anim.easing
 				});


### PR DESCRIPTION
I ran into this issue when trying to set the start/end properties in a block as functions. In my situation I have a div that has height: 'auto' then I programmatically calculate the height based on the computed value. This allowed the containers to have the proper height on different device widths.
