### PR TITLE
Only create div#scroll-wrap once

### DIFF
--- a/js/jquery.scrollorama.js
+++ b/js/jquery.scrollorama.js
@@ -65,7 +65,10 @@
 				}
 			}
 			
-			$('body').prepend('<div id="scroll-wrap"></div>');
+			// create scroll-wrap div only once
+			if ($("#scroll-wrap").length === 0) {
+				$('body').prepend('<div id="scroll-wrap"></div>');
+			}
 			
 			latestKnownScrollY = 0;
             ticking = false;


### PR DESCRIPTION
I have an situation where I need to reinitialize scrollorama to update the values from the start/end functions but when I make the call to my scrollorama function it creates this empty div#scroll-wrap in the document every time I make that call. I do this because the animation end values could change and I need them not to snap back to the original position. This is just checking to see if the div is in the DOM already so that it only creates that element once. 

Maybe there is a better way to re-init scrollorama so that those values are updated?

Also, I'm still unclear as to why we need that empty div in the first place but I wanted to put this here and get your input.

Thanks,

-A
