### PR TITLE
Please look my pull request for IE scale bugfix

### DIFF
--- a/js/jquery.scrollorama.js
+++ b/js/jquery.scrollorama.js
@@ -206,7 +206,8 @@
 					if (browserPrefix !== '-ms-') {
 						target.css(browserPrefix+'transform', scaleCSS);
 					} else {
-						target.css('zoom', scaleCSS);
+						if (jQuery().scale) $(target.selector).scale(val);
+						target.css('zoom', val);
 					}
 				}
 			}


### PR DESCRIPTION
I just changed the css property zoom to receive the variable "val" (numeric) instead of "scaleCSS" (css3 transform information). I tryied and it works.

I also added the following line:
if (jQuery () scale.) $ (target.selector) scale (val).;
If someone is using the plugin "jquery-animate-css-rotate-scale.js" that makes changes using jquery instead of css, for older browsers, it works better than using the zoom property. If the plugin was not loaded zoom will be fired anyway. My final change is as follows:

if (jQuery().scale) $(target.selector).scale(val);
else target.css('zoom', val);
