### PR TITLE
Animate all blocks that are within the viewport, not just two

### DIFF
--- a/js/jquery.scrollorama.js
+++ b/js/jquery.scrollorama.js
@@ -101,6 +101,7 @@
 		function onScrollorama() {
 			var scrollTop = $(window).scrollTop(),
 			currBlockIndex = getCurrBlockIndex(scrollTop),
+			wheight = $(window).height(),
 			i, j, anim, startAnimPos, endAnimPos, animPercent, animVal;
 			
 			// update all animations
@@ -135,7 +136,7 @@
 						}
 						
 						// otherwise, set values per scroll position
-						if (i === currBlockIndex || (currBlockIndex === i-1 && anim.baseline === 'bottom')) {
+						if (blocks[i].top + blocks[i].block.height() >= scrollTop && blocks[i].top <= (scrollTop + wheight)) {
 							// if block gets pinned, set position fixed
 							if (blocks[i].pin && currBlockIndex === i) {
 								blocks[i].block
@@ -145,7 +146,7 @@
 							
 							// set start and end animation positions
 							startAnimPos = blocks[i].top + anim.delay;
-							if (anim.baseline === 'bottom') { startAnimPos -= $(window).height(); }
+							if (anim.baseline === 'bottom') { startAnimPos -= wheight; }
 							endAnimPos = startAnimPos + anim.duration;
 							
 							// if scroll is before start of animation, set to start value


### PR DESCRIPTION
Right now, only two blocks at any given time are being animated. On large screen resolutions or with small block sizes, this can cause animations to jump from their starting position to somewhere halfway through the animation. Or if you scroll really fast past an animation and then scroll slowly to it, you'll the animation stuck halfway and then jump to its initial position once it starts animating.

You can see this behaviour on your demo as well, especially with the word "easing".

![Screenshot](https://f.cloud.github.com/assets/864507/189482/0114ba0e-7e88-11e2-83b2-86f1b6dcb491.png)

This is the bottom of my screen and the animation is stuck somewhere below.
